### PR TITLE
Handle optional dependencies and fix text file output

### DIFF
--- a/tests/test_make_output_text.py
+++ b/tests/test_make_output_text.py
@@ -1,0 +1,12 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from imgProc_Binary_gdal import make_output_text
+
+
+def test_make_output_text(tmp_path):
+    filename = "out.txt"
+    data = ["first", "second"]
+    make_output_text(filename, tmp_path, data)
+    out_file = tmp_path / filename
+    assert out_file.exists()
+    assert out_file.read_text() == "first\nsecond\n"


### PR DESCRIPTION
## Summary
- Avoid hard dependency on GDAL, NumPy, Numba and scikit-image by importing them lazily
- Raise informative ImportError when GDAL is required but missing
- Fix `make_output_text` to write lines correctly in text mode
- Add tests for text file export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc65fe22083229bb9d5f935dcb153