### PR TITLE
Handle optional dependencies and fix text file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # py3_Img_binary
+
+Utilities for thresholding raster images and exporting geospatial or text
+outputs.  The repository contains a small collection of functions that were
+originally part of a GDAL‑based binary image processing script.
+
+## Features
+
+- Extract geospatial parameters from raster datasets
+- Create georeferenced output rasters from NumPy arrays
+- Compute Otsu thresholds and apply them to produce binary images
+- Export plain text files, e.g. threshold reports
+
+## Optional dependencies
+
+The core of the project relies on several heavy third‑party libraries.  They
+are imported lazily so that light‑weight utilities can be used without the full
+stack.  Install them as needed:
+
+- [GDAL](https://gdal.org/) – reading and writing raster data
+- [NumPy](https://numpy.org/) – array manipulation
+- [Numba](https://numba.pydata.org/) – optional JIT acceleration
+- [scikit-image](https://scikit-image.org/) – image processing helpers
+
+## Usage
+
+```python
+from imgProc_Binary_gdal import make_output_text
+
+# write a CSV file containing threshold values
+make_output_text("threshold.csv", "./", ["image1,42", "image2,101"])
+```
+
+Other functions in the module require the optional dependencies listed above.
+
+## Development
+
+Run the unit tests to verify the behaviour:
+
+```bash
+pytest -q
+```
+

--- a/tests/test_make_output_text.py
+++ b/tests/test_make_output_text.py
@@ -1,0 +1,12 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from imgProc_Binary_gdal import make_output_text
+
+
+def test_make_output_text(tmp_path):
+    filename = "out.txt"
+    data = ["first", "second"]
+    make_output_text(filename, tmp_path, data)
+    out_file = tmp_path / filename
+    assert out_file.exists()
+    assert out_file.read_text() == "first\nsecond\n"


### PR DESCRIPTION
## Summary
- Avoid hard dependency on GDAL, NumPy, Numba and scikit-image by importing them lazily
- Raise informative ImportError when GDAL is required but missing
- Fix `make_output_text` to write lines correctly in text mode
- Add tests for text file export
- Document project features and optional dependencies in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc65fe22083229bb9d5f935dcb153